### PR TITLE
curl dependency was changed to hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ exclude = ["examples/*", "tests/*"]
 keywords = ["firebase", "rest", "api"]
 
 [dependencies]
-url  = "0.2.35"
-curl = "0.2.10"
-rustc-serialize = "0.3.15"
+url  = "0.5"
+hyper = "0.7"
+rustc-serialize = "0.3"


### PR DESCRIPTION
curl dependency is hard to handle with Cygwin and MSVC toolchains.
In this PR that dependency was changed to hyper crate. It's pure Rust and has good support for different platforms.
